### PR TITLE
Update help_upload_template.md

### DIFF
--- a/inst/comoapp/www/markdown/help_upload_template.md
+++ b/inst/comoapp/www/markdown/help_upload_template.md
@@ -1,1 +1,1 @@
- Download the <a href="https://github.com/ocelhay/como/blob/master/Template_CoMoCOVID-19App_v18.xlsx" target="_blank">version 18 of the template</a>, edit the file and upload it.
+ Download the <a href="https://github.com/ocelhay/como/raw/v18/Template_CoMoCOVID-19App_v18.xlsx" target="_blank">version 18 of the template</a>, edit the file and upload it.


### PR DESCRIPTION
- update link to v18 template which is still on v18 branch
- @ocelhay  going forward can we pls link to the `raw` version (instead of `blob/master`) of the template so that a direct download is triggered?